### PR TITLE
Enable event tracking at the page component level

### DIFF
--- a/src/usePageTracking.js
+++ b/src/usePageTracking.js
@@ -32,5 +32,21 @@ export default function usePageTracking(
     }
   }, [trackPageViewByDefault, trackPageView]);
 
-  return { trackPageView };
+  const result = useMemo(() => {
+    const eventTracking = getEventTracking();
+
+    return Object.keys(eventTracking).reduce((acc, key) => {
+      acc[key] = (eventData) => {
+        if (typeof eventTracking[key] === "function") {
+          const siteData = getSiteData();
+          const pageData = getPageData();
+
+          return eventTracking[key]({ siteData, pageData, eventData });
+        }
+      };
+      return acc;
+    }, {});
+  }, [getSiteData, getEventTracking, getPageData]);
+
+  return { ...result, trackPageView };
 }


### PR DESCRIPTION
We should return the functions from event tracking to page components, this PR allows the use of event tracking for the page component.

It treats `usePageTracking` as similar to `useForm` in RHF. Where the `useForm` returns all `methods` available on it to be used immediately within that component.

Similarly `useEventTracking` would be similar to `useFormContext` which does not create a new context but instead simply allows the use of `methods` returned by `useForm`.